### PR TITLE
Add feature to handle multiple attempts of subscriptions

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,10 +1,11 @@
+//! Configurations module.
+//!
+//! This module includes two `struct`s: [Settings] and [DatabaseSettings] that
+//! describe all the configuration attributes that are needed to setup
+//! the execution and test environments of the **newsletter** application.
+
 use crate::domain::SubscriberEmail;
 use secrecy::{ExposeSecret, Secret};
-/// Configurations module.
-///
-/// This module includes two `struct`s: [Settings] and [DatabaseSettings] that
-/// describe all the configuration attributes that are needed to setup
-/// the execution and test environments of the **newsletter** application.
 use serde;
 use serde_aux::field_attributes::deserialize_number_from_string;
 use sqlx::{

--- a/src/routes/health_check.rs
+++ b/src/routes/health_check.rs
@@ -1,4 +1,5 @@
-/// Module that includes a health check endpoint.
+//! Module that includes a health check endpoint.
+
 use actix_web::{get, HttpResponse, Responder};
 
 /// Endpoint that tells a client about the server health status.

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -1,7 +1,7 @@
+//! Module that includes helper functions to start the **newsletter** application.
+
 use crate::configuration::DatabaseSettings;
 use crate::configuration::Settings;
-/// Module that includes helper functions to start the **newsletter** application.
-///
 use crate::routes;
 use crate::EmailClient;
 use actix_web::{dev::Server, web, App, HttpServer};


### PR DESCRIPTION
This feature allows to handle the scenario in which a client attempts
to subscribe multiple times using the samde address. An existing
confimration token gets removed when a new attempt is issued before
the confirmation endpoint is triggered.